### PR TITLE
Add Tiebreaker to Window Functions

### DIFF
--- a/macros/activity_occurrence.sql
+++ b/macros/activity_occurrence.sql
@@ -4,18 +4,16 @@ row_number() over (
     partition by
         coalesce(
             {{ safe_cast("customer", type_string()) }},
-            {{ safe_cast("activity", type_string()) }},
             {{ safe_cast("anonymous_customer_id", type_string()) }}
-        )
+        ) || {{ safe_cast("activity", type_string()) }}
     order by ts asc, activity_id asc
 ) as activity_occurrence,
 lead(ts) over (
     partition by
         coalesce(
             {{ safe_cast("customer", type_string()) }},
-            {{ safe_cast("activity", type_string()) }},
             {{ safe_cast("anonymous_customer_id", type_string()) }}
-        )
+        ) || {{ safe_cast("activity", type_string()) }}
     order by ts asc, activity_id asc
 ) as activity_repeated_at
 {% endmacro %}

--- a/macros/activity_occurrence.sql
+++ b/macros/activity_occurrence.sql
@@ -1,14 +1,19 @@
 {# Creates the two activity occurrence columns: activity_occurrence and activity_repeated_at  #}
-
 {% macro activity_occurrence() %}
-    row_number() over (
-        partition by coalesce (
+row_number() over (
+    partition by
+        coalesce(
             {{ safe_cast("customer", type_string()) }},
             {{ safe_cast("anonymous_customer_id", type_string()) }}
-            ) order by ts asc ) as activity_occurrence,
-    lead(ts) over (
-        partition by coalesce (
+        )
+    order by ts asc, activity_id asc
+) as activity_occurrence,
+lead(ts) over (
+    partition by
+        coalesce(
             {{ safe_cast("customer", type_string()) }},
             {{ safe_cast("anonymous_customer_id", type_string()) }}
-        ) order by ts asc) as activity_repeated_at
+        )
+    order by ts asc, activity_id asc
+) as activity_repeated_at
 {% endmacro %}

--- a/macros/activity_occurrence.sql
+++ b/macros/activity_occurrence.sql
@@ -4,6 +4,7 @@ row_number() over (
     partition by
         coalesce(
             {{ safe_cast("customer", type_string()) }},
+            {{ safe_cast("activity", type_string()) }},
             {{ safe_cast("anonymous_customer_id", type_string()) }}
         )
     order by ts asc, activity_id asc
@@ -12,6 +13,7 @@ lead(ts) over (
     partition by
         coalesce(
             {{ safe_cast("customer", type_string()) }},
+            {{ safe_cast("activity", type_string()) }},
             {{ safe_cast("anonymous_customer_id", type_string()) }}
         )
     order by ts asc, activity_id asc


### PR DESCRIPTION
Per this #1, current implementation of these macros will not resolve deterministically if `ts` is identical, which can happen when working with timestamps cast from dates. Adding the PK to the window function will ensure that the window functions resolve the same way each time, and should not affect any results that do not have this edge case. 